### PR TITLE
IntegrityException error importing rows with same pk

### DIFF
--- a/src/import/basic/Importer.php
+++ b/src/import/basic/Importer.php
@@ -44,14 +44,10 @@ class Importer extends BaseImporter
 
         $this->fillModels($this->_phpExcel->getActiveSheet()->getRowIterator());
 
-        foreach ($this->_models as $model) {
-            $model->load();
-            $model->validate();
-        }
-
         Yii::$app->db->transaction(function () {
             foreach ($this->_models as $model) {
-                $model->save(false);
+                $model->load();
+                $model->save();
             }
         });
 


### PR DESCRIPTION
This fix allows to update the previous imported row with the new one (of course by pk) oherwise it throws \yii\db\IntegrityException