### PR TITLE
Fixed PHP 7.2 problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ The preferred way to install this extension is through [composer](http://getcomp
 Either run
 
 ```
-php composer.phar require --prefer-dist arogachev/yii2-excel
+php composer.phar require --prefer-dist divad942/yii2-excel
 ```
 
 or add
 
 ```
-"arogachev/yii2-excel": "*"
+"divad942/yii2-excel": "*"
 ```
 
 to the require section of your `composer.json` file.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Yii 2 Excel
 
+** This is fork of https://github.com/arogachev/yii2-excel **
+Fixed compatibility issues with PHP 7.2 
+
 ActiveRecord import and export based on PHPExcel for Yii 2 framework.
 
 This library is mainly designed to import data, export is in the raw condition (even it's working in basic form),

--- a/README.md
+++ b/README.md
@@ -1,26 +1,10 @@
 # Yii 2 Excel
 
-** This is fork of https://github.com/arogachev/yii2-excel **
-Fixed compatibility issues with PHP 7.2 
+This is fork of https://github.com/arogachev/yii2-excel
+
+Fixed compatibility issues with PHP 7.2
 
 ActiveRecord import and export based on PHPExcel for Yii 2 framework.
-
-This library is mainly designed to import data, export is in the raw condition (even it's working in basic form),
-under development and not documented yet.
-
-The important notes:
-
-- It uses ActiveRecord models and PHPExcel library, so operating big data requires pretty good hardware, especially RAM.
-In case of memory shortage I can advise splitting data into smaller chunks.
-- This is not just a wrapper on some PHPExcel methods, it's a tool helping import data from Excel in human readable
-form with minimal configuration.
-- This is designed for periodical import.
-- The library is more effective when working with multiple related models and complex data structures.
-
-[![Latest Stable Version](https://poser.pugx.org/arogachev/yii2-excel/v/stable)](https://packagist.org/packages/arogachev/yii2-excel)
-[![Total Downloads](https://poser.pugx.org/arogachev/yii2-excel/downloads)](https://packagist.org/packages/arogachev/yii2-excel)
-[![Latest Unstable Version](https://poser.pugx.org/arogachev/yii2-excel/v/unstable)](https://packagist.org/packages/arogachev/yii2-excel)
-[![License](https://poser.pugx.org/arogachev/yii2-excel/license)](https://packagist.org/packages/arogachev/yii2-excel)
 
 - [Installation](#installation)
 - [Import Basics](docs/import-basics.md)

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "autoload": {
         "psr-4": {
-            "arogachev\\excel\\": "src"
+            "divad942\\excel\\": "src"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "arogachev/yii2-excel",
+    "name": "divad942/yii2-excel",
     "description": "ActiveRecord import and export based on PHPExcel for Yii 2 framework",
     "keywords": [
         "yii2",
@@ -9,17 +9,17 @@
         "export",
         "active record"
     ],
-    "homepage": "https://github.com/arogachev/yii2-excel",
+    "homepage": "https://github.com/divad942/yii2-excel",
     "type": "yii2-extension",
     "license": "BSD-3-Clause",
     "authors": [
         {
-            "name": "Alexey Rogachev",
-            "email": "arogachev90@gmail.com"
+            "name": "David Baselj",
+            "email": "divad942@gmail.com"
         }
     ],
     "require": {
-        "yiisoft/yii2": "*",
+        "yiisoft/yii2": ">=2.0.13",
         "phpoffice/phpexcel": "1.8.*"
     },
     "require-dev": {

--- a/docs/import-advanced.md
+++ b/docs/import-advanced.md
@@ -29,7 +29,7 @@ better understanding.
 *Configuration example:*
 
 ```php
-use arogachev\excel\import\advanced\Importer;
+use divad942\excel\import\advanced\Importer;
 use frontend\models\Answer;
 use frontend\models\Category;
 use frontend\models\Question;

--- a/docs/import-basic.md
+++ b/docs/import-basic.md
@@ -12,7 +12,7 @@
 *Configuration example:*
 
 ```php
-use arogachev\excel\import\basic\Importer;
+use divad942\excel\import\basic\Importer;
 use frontend\models\Category;
 use frontend\models\Test;
 use Yii;

--- a/src/behaviors/CellBehavior.php
+++ b/src/behaviors/CellBehavior.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace arogachev\excel\behaviors;
+namespace divad942\excel\behaviors;
 
-use arogachev\excel\import\advanced\Attribute;
-use arogachev\excel\import\DI;
+use divad942\excel\import\advanced\Attribute;
+use divad942\excel\import\DI;
 use yii\base\Behavior;
 
 class CellBehavior extends Behavior

--- a/src/components/Attribute.php
+++ b/src/components/Attribute.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace arogachev\excel\components;
+namespace divad942\excel\components;
 
 use yii\base\Component;
 

--- a/src/components/Model.php
+++ b/src/components/Model.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace arogachev\excel\components;
+namespace divad942\excel\components;
 
 use yii\base\Component;
 
@@ -23,7 +23,7 @@ abstract class Model extends Component
     /**
      * @var string
      */
-    protected static $attributeClassName = 'arogachev\excel\components\Attribute';
+    protected static $attributeClassName = 'divad942\excel\components\Attribute';
 
     /**
      * @var \yii\db\ActiveRecord

--- a/src/components/StandardAttribute.php
+++ b/src/components/StandardAttribute.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace arogachev\excel\components;
+namespace divad942\excel\components;
 
-use arogachev\excel\exceptions\StandardAttributeException;
+use divad942\excel\exceptions\StandardAttributeException;
 use yii\base\BaseObject;
 
 /**

--- a/src/components/StandardAttribute.php
+++ b/src/components/StandardAttribute.php
@@ -9,7 +9,7 @@ use yii\base\BaseObject;
  * @property StandardModel $standardModel
  * @property string $column
  */
-class StandardAttribute extends Object
+class StandardAttribute extends BaseObject
 {
     /**
      * @var string

--- a/src/components/StandardAttribute.php
+++ b/src/components/StandardAttribute.php
@@ -3,7 +3,7 @@
 namespace arogachev\excel\components;
 
 use arogachev\excel\exceptions\StandardAttributeException;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * @property StandardModel $standardModel

--- a/src/components/StandardModel.php
+++ b/src/components/StandardModel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace arogachev\excel\components;
+namespace divad942\excel\components;
 
 use yii\base\InvalidParamException;
 use yii\base\BaseObject;
@@ -35,7 +35,7 @@ class StandardModel extends Object
     /**
      * @var string
      */
-    protected static $standardAttributeClassName = 'arogachev\excel\components\StandardAttribute';
+    protected static $standardAttributeClassName = 'divad942\excel\components\StandardAttribute';
 
     /**
      * @var \yii\db\ActiveRecord

--- a/src/components/StandardModel.php
+++ b/src/components/StandardModel.php
@@ -10,7 +10,7 @@ use yii\helpers\ArrayHelper;
  * @property StandardAttribute[] $standardAttributes
  * @property \yii\db\ActiveRecord $instance
  */
-class StandardModel extends Object
+class StandardModel extends BaseObject
 {
     /**
      * @var string

--- a/src/components/StandardModel.php
+++ b/src/components/StandardModel.php
@@ -3,7 +3,7 @@
 namespace arogachev\excel\components;
 
 use yii\base\InvalidParamException;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\ArrayHelper;
 
 /**

--- a/src/exceptions/StandardAttributeException.php
+++ b/src/exceptions/StandardAttributeException.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace arogachev\excel\exceptions;
+namespace divad942\excel\exceptions;
 
-use arogachev\excel\components\StandardAttribute;
+use divad942\excel\components\StandardAttribute;
 use yii\base\Exception;
 
 class StandardAttributeException extends Exception

--- a/src/export/basic/Attribute.php
+++ b/src/export/basic/Attribute.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace arogachev\excel\export\basic;
+namespace divad942\excel\export\basic;
 
-use arogachev\excel\components\Attribute as BaseAttribute;
-use arogachev\excel\export\exceptions\ExportException;
+use divad942\excel\components\Attribute as BaseAttribute;
+use divad942\excel\export\exceptions\ExportException;
 use yii\base\InvalidParamException;
 
 /**

--- a/src/export/basic/Exporter.php
+++ b/src/export/basic/Exporter.php
@@ -4,7 +4,7 @@ namespace arogachev\excel\export\basic;
 
 use PHPExcel;
 use PHPExcel_IOFactory;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 class Exporter extends Object
 {

--- a/src/export/basic/Exporter.php
+++ b/src/export/basic/Exporter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace arogachev\excel\export\basic;
+namespace divad942\excel\export\basic;
 
 use PHPExcel;
 use PHPExcel_IOFactory;

--- a/src/export/basic/Model.php
+++ b/src/export/basic/Model.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace arogachev\excel\export\basic;
+namespace divad942\excel\export\basic;
 
-use arogachev\excel\components\Model as BaseModel;
+use divad942\excel\components\Model as BaseModel;
 
 /**
  * @var StandardModel $standardModel
@@ -12,7 +12,7 @@ class Model extends BaseModel
     /**
      * @inheritdoc
      */
-    protected static $attributeClassName = 'arogachev\excel\export\basic\Attribute';
+    protected static $attributeClassName = 'divad942\excel\export\basic\Attribute';
 
     /**
      * @inheritdoc

--- a/src/export/basic/StandardAttribute.php
+++ b/src/export/basic/StandardAttribute.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace arogachev\excel\export\basic;
+namespace divad942\excel\export\basic;
 
-use arogachev\excel\components\StandardAttribute as BaseStandardAttribute;
+use divad942\excel\components\StandardAttribute as BaseStandardAttribute;
 
 /**
  * @var StandardModel $standardModel

--- a/src/export/basic/StandardModel.php
+++ b/src/export/basic/StandardModel.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace arogachev\excel\export\basic;
+namespace divad942\excel\export\basic;
 
-use arogachev\excel\components\StandardModel as BaseStandardModel;
-use arogachev\excel\export\exceptions\ExportException;
+use divad942\excel\components\StandardModel as BaseStandardModel;
+use divad942\excel\export\exceptions\ExportException;
 
 /**
  * @property StandardAttribute[] $standardAttributes
@@ -18,7 +18,7 @@ class StandardModel extends BaseStandardModel
     /**
      * @inheritdoc
      */
-    protected static $standardAttributeClassName = 'arogachev\excel\export\basic\StandardAttribute';
+    protected static $standardAttributeClassName = 'divad942\excel\export\basic\StandardAttribute';
 
 
     /**

--- a/src/export/exceptions/ExportException.php
+++ b/src/export/exceptions/ExportException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace arogachev\excel\export\exceptions;
+namespace divad942\excel\export\exceptions;
 
 use yii\base\Exception;
 

--- a/src/helpers/PHPExcelHelper.php
+++ b/src/helpers/PHPExcelHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace arogachev\excel\helpers;
+namespace divad942\excel\helpers;
 
 class PHPExcelHelper
 {

--- a/src/import/BaseImporter.php
+++ b/src/import/BaseImporter.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace arogachev\excel\import;
+namespace divad942\excel\import;
 
-use arogachev\excel\import\basic\Model;
-use arogachev\excel\import\basic\StandardModel;
-use arogachev\excel\import\exceptions\ImportException;
+use divad942\excel\import\basic\Model;
+use divad942\excel\import\basic\StandardModel;
+use divad942\excel\import\exceptions\ImportException;
 use PHPExcel;
 use PHPExcel_IOFactory;
 use Yii;

--- a/src/import/CellParser.php
+++ b/src/import/CellParser.php
@@ -4,7 +4,7 @@ namespace arogachev\excel\import;
 
 use arogachev\excel\import\exceptions\CellException;
 use PHPExcel_Cell;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 class CellParser extends Object
 {

--- a/src/import/CellParser.php
+++ b/src/import/CellParser.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace arogachev\excel\import;
+namespace divad942\excel\import;
 
-use arogachev\excel\import\exceptions\CellException;
+use divad942\excel\import\exceptions\CellException;
 use PHPExcel_Cell;
 use yii\base\BaseObject;
 

--- a/src/import/CellParser.php
+++ b/src/import/CellParser.php
@@ -6,7 +6,7 @@ use divad942\excel\import\exceptions\CellException;
 use PHPExcel_Cell;
 use yii\base\BaseObject;
 
-class CellParser extends Object
+class CellParser extends BaseObject
 {
     // Hex color codes
 

--- a/src/import/DI.php
+++ b/src/import/DI.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace arogachev\excel\import;
+namespace divad942\excel\import;
 
-use arogachev\excel\import\advanced\Importer as AdvancedImporter;
-use arogachev\excel\import\basic\Importer as BasicImporter;
+use divad942\excel\import\advanced\Importer as AdvancedImporter;
+use divad942\excel\import\basic\Importer as BasicImporter;
 use PHPExcel;
 use Yii;
 

--- a/src/import/advanced/Attribute.php
+++ b/src/import/advanced/Attribute.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace arogachev\excel\import\advanced;
+namespace divad942\excel\import\advanced;
 
-use arogachev\excel\behaviors\CellBehavior;
-use arogachev\excel\import\basic\Attribute as BasicAttribute;
-use arogachev\excel\import\DI;
-use arogachev\excel\import\exceptions\CellException;
+use divad942\excel\behaviors\CellBehavior;
+use divad942\excel\import\basic\Attribute as BasicAttribute;
+use divad942\excel\import\DI;
+use divad942\excel\import\exceptions\CellException;
 use Yii;
 
 /**

--- a/src/import/advanced/Importer.php
+++ b/src/import/advanced/Importer.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace arogachev\excel\import\advanced;
+namespace divad942\excel\import\advanced;
 
-use arogachev\excel\helpers\PHPExcelHelper;
-use arogachev\excel\import\BaseImporter;
-use arogachev\excel\import\CellParser;
-use arogachev\excel\import\exceptions\CellException;
-use arogachev\excel\import\exceptions\RowException;
+use divad942\excel\helpers\PHPExcelHelper;
+use divad942\excel\import\BaseImporter;
+use divad942\excel\import\CellParser;
+use divad942\excel\import\exceptions\CellException;
+use divad942\excel\import\exceptions\RowException;
 use PHPExcel_Cell;
 use Yii;
 use yii\base\InvalidConfigException;

--- a/src/import/advanced/Model.php
+++ b/src/import/advanced/Model.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace arogachev\excel\import\advanced;
+namespace divad942\excel\import\advanced;
 
-use arogachev\excel\import\basic\Model as BasicModel;
-use arogachev\excel\import\DI;
+use divad942\excel\import\basic\Model as BasicModel;
+use divad942\excel\import\DI;
 use Yii;
 use yii\helpers\ArrayHelper;
 
@@ -84,7 +84,7 @@ class Model extends BasicModel
     /**
      * @param Attribute $defaultAttribute
      * @param null|integer $index
-     * @throws \arogachev\excel\import\exceptions\CellException
+     * @throws \divad942\excel\import\exceptions\CellException
      */
     protected function mergeDefaultAttribute($defaultAttribute, $index = null)
     {

--- a/src/import/advanced/StandardModel.php
+++ b/src/import/advanced/StandardModel.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace arogachev\excel\import\advanced;
+namespace divad942\excel\import\advanced;
 
-use arogachev\excel\import\basic\StandardModel as BasicStandardModel;
+use divad942\excel\import\basic\StandardModel as BasicStandardModel;
 
 /**
  * @property Attribute[] $defaultAttributes

--- a/src/import/basic/Attribute.php
+++ b/src/import/basic/Attribute.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace arogachev\excel\import\basic;
+namespace divad942\excel\import\basic;
 
-use arogachev\excel\components\Attribute as BaseAttribute;
-use arogachev\excel\import\exceptions\CellException;
+use divad942\excel\components\Attribute as BaseAttribute;
+use divad942\excel\import\exceptions\CellException;
 use PHPExcel_Cell;
 use yii\base\Component;
 use yii\base\InvalidParamException;

--- a/src/import/basic/Importer.php
+++ b/src/import/basic/Importer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace arogachev\excel\import\basic;
+namespace divad942\excel\import\basic;
 
-use arogachev\excel\helpers\PHPExcelHelper;
-use arogachev\excel\import\BaseImporter;
-use arogachev\excel\import\exceptions\RowException;
+use divad942\excel\helpers\PHPExcelHelper;
+use divad942\excel\import\BaseImporter;
+use divad942\excel\import\exceptions\RowException;
 use Yii;
 
 class Importer extends BaseImporter

--- a/src/import/basic/Model.php
+++ b/src/import/basic/Model.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace arogachev\excel\import\basic;
+namespace divad942\excel\import\basic;
 
-use arogachev\excel\components\Model as BaseModel;
-use arogachev\excel\import\DI;
-use arogachev\excel\import\exceptions\RowException;
+use divad942\excel\components\Model as BaseModel;
+use divad942\excel\import\DI;
+use divad942\excel\import\exceptions\RowException;
 use PHPExcel_Worksheet_Row;
 use yii\base\Component;
 
@@ -23,7 +23,7 @@ class Model extends BaseModel
     /**
      * @inheritdoc
      */
-    protected static $attributeClassName = 'arogachev\excel\import\basic\Attribute';
+    protected static $attributeClassName = 'divad942\excel\import\basic\Attribute';
 
 
     /**

--- a/src/import/basic/StandardAttribute.php
+++ b/src/import/basic/StandardAttribute.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace arogachev\excel\import\basic;
+namespace divad942\excel\import\basic;
 
-use arogachev\excel\components\StandardAttribute as BaseStandardAttribute;
-use arogachev\excel\exceptions\StandardAttributeException;
+use divad942\excel\components\StandardAttribute as BaseStandardAttribute;
+use divad942\excel\exceptions\StandardAttributeException;
 use yii\base\BaseObject;
 use yii\helpers\ArrayHelper;
 

--- a/src/import/basic/StandardAttribute.php
+++ b/src/import/basic/StandardAttribute.php
@@ -4,7 +4,7 @@ namespace arogachev\excel\import\basic;
 
 use arogachev\excel\components\StandardAttribute as BaseStandardAttribute;
 use arogachev\excel\exceptions\StandardAttributeException;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\ArrayHelper;
 
 /**

--- a/src/import/basic/StandardModel.php
+++ b/src/import/basic/StandardModel.php
@@ -8,7 +8,7 @@ use arogachev\excel\import\exceptions\RowException;
 use PHPExcel_Worksheet_Row;
 use yii\base\Event;
 use yii\base\InvalidParamException;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\db\ActiveRecord;
 use yii\helpers\ArrayHelper;
 

--- a/src/import/basic/StandardModel.php
+++ b/src/import/basic/StandardModel.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace arogachev\excel\import\basic;
+namespace divad942\excel\import\basic;
 
-use arogachev\excel\components\StandardModel as BaseStandardModel;
-use arogachev\excel\import\exceptions\CellException;
-use arogachev\excel\import\exceptions\RowException;
+use divad942\excel\components\StandardModel as BaseStandardModel;
+use divad942\excel\import\exceptions\CellException;
+use divad942\excel\import\exceptions\RowException;
 use PHPExcel_Worksheet_Row;
 use yii\base\Event;
 use yii\base\InvalidParamException;
@@ -27,7 +27,7 @@ class StandardModel extends BaseStandardModel
     /**
      * @inheritdoc
      */
-    protected static $standardAttributeClassName = 'arogachev\excel\import\basic\StandardAttribute';
+    protected static $standardAttributeClassName = 'divad942\excel\import\basic\StandardAttribute';
 
     /**
      * @var array

--- a/src/import/exceptions/CellException.php
+++ b/src/import/exceptions/CellException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace arogachev\excel\import\exceptions;
+namespace divad942\excel\import\exceptions;
 
 use PHPExcel_Cell;
 

--- a/src/import/exceptions/ImportException.php
+++ b/src/import/exceptions/ImportException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace arogachev\excel\import\exceptions;
+namespace divad942\excel\import\exceptions;
 
 use yii\base\Exception;
 

--- a/src/import/exceptions/RowException.php
+++ b/src/import/exceptions/RowException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace arogachev\excel\import\exceptions;
+namespace divad942\excel\import\exceptions;
 
 use PHPExcel_Worksheet_Row;
 

--- a/tests/unit/AdvancedImporterTest.php
+++ b/tests/unit/AdvancedImporterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use arogachev\excel\import\advanced\Importer;
+use divad942\excel\import\advanced\Importer;
 use data\Answer;
 use data\Author;
 use data\Question;

--- a/tests/unit/BasicExporterTest.php
+++ b/tests/unit/BasicExporterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use arogachev\excel\export\basic\Exporter;
+use divad942\excel\export\basic\Exporter;
 use data\Test;
 use yii\codeception\TestCase;
 use yii\helpers\HtmlPurifier;

--- a/tests/unit/BasicImporterTest.php
+++ b/tests/unit/BasicImporterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use arogachev\excel\import\basic\Importer;
+use divad942\excel\import\basic\Importer;
 use data\Author;
 use data\Test;
 use yii\codeception\TestCase;


### PR DESCRIPTION
in yii2 actual version this lib doesn't work showing this error message:
Cannot use yii\base\Object as Object because 'Object' is a special class name

This fork solve this problem